### PR TITLE
fix: icmp connection reset message will trigger disconnect

### DIFF
--- a/src/lib/Connector.cs
+++ b/src/lib/Connector.cs
@@ -24,6 +24,8 @@ SOFTWARE.
 
 */
 
+using System.Net.Sockets;
+
 namespace Piot.Brisk.Connect
 {
     using System.Diagnostics;
@@ -719,7 +721,14 @@ namespace Piot.Brisk.Connect
 
         void IPacketReceiver.HandleException(Exception e)
         {
-            log.Warning(e.ToString());
+            log.Warning(e.ToString()); 
+            
+            if (e is SocketException se && se.SocketErrorCode == SocketError.ConnectionReset) 
+            {
+                // Suppress infinite warning for "System.Net.Sockets.SocketException (0x80004005): An existing connection was forcibly closed by the remote host."
+                SwitchState(ConnectionState.Disconnected, 9999);
+            } 
+            
             //receiveStream.HandleException(e);
         }
         public ConnectionState ConnectionState => state;

--- a/src/lib/Connector.cs
+++ b/src/lib/Connector.cs
@@ -721,14 +721,14 @@ namespace Piot.Brisk.Connect
 
         void IPacketReceiver.HandleException(Exception e)
         {
-            log.Warning(e.ToString()); 
-            
-            if (e is SocketException se && se.SocketErrorCode == SocketError.ConnectionReset) 
+            log.Warning(e.ToString());
+
+            if (e is SocketException se && se.SocketErrorCode == SocketError.ConnectionReset)
             {
                 // Suppress infinite warning for "System.Net.Sockets.SocketException (0x80004005): An existing connection was forcibly closed by the remote host."
                 SwitchState(ConnectionState.Disconnected, 9999);
-            } 
-            
+            }
+
             //receiveStream.HandleException(e);
         }
         public ConnectionState ConnectionState => state;


### PR DESCRIPTION
This prevents infinite warnings spammed to the console when a connection is closed on some machines.
The magic number 9999 is  copied from line 430, I am not sure how we should deal with it.